### PR TITLE
handle driver timeout error

### DIFF
--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -371,6 +371,8 @@ func (this *Applier) ReadMigrationMinValues(uniqueKey *sql.UniqueKey) error {
 		}
 	}
 	log.Infof("Migration min values: [%s]", this.migrationContext.MigrationRangeMinValues)
+
+	err = rows.Err()
 	return err
 }
 
@@ -392,6 +394,8 @@ func (this *Applier) ReadMigrationMaxValues(uniqueKey *sql.UniqueKey) error {
 		}
 	}
 	log.Infof("Migration max values: [%s]", this.migrationContext.MigrationRangeMaxValues)
+
+	err = rows.Err()
 	return err
 }
 

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -444,6 +444,9 @@ func (this *Applier) CalculateNextIterationRangeEndValues() (hasFurtherRange boo
 			}
 			hasFurtherRange = true
 		}
+		if err = rows.Err(); err != nil {
+			return hasFurtherRange, err
+		}
 		if hasFurtherRange {
 			this.migrationContext.MigrationIterationRangeMaxValues = iterationRangeMaxValues
 			return hasFurtherRange, nil


### PR DESCRIPTION
Heh, sorry for the mess. Replaces #3 

re-submitting https://github.com/github/gh-ost/pull/835 by @ajm188 

Closes #822.

In go-sql-driver/mysql#1075, @acharis notes
that the way the go-sql driver is written, query timeout errors don't
get set in rows.Err() until after a call to rows.Next() is made.

Because this kind of error means there will be no rows in the result
set, the for rows.Next() will never enter the for loop, so we must
check the value of rows.Err() after the loop, and surface the error up
appropriately.

I then went ahead and fixed up the error checking in the two remaining
places we use db.Query, and validated I've covered all cases by
running:

```
$ golangci-lint run --disable-all -E rowserrcheck
```