### PR TITLE
Support ALTER ONLINE TABLE syntax

### DIFF
--- a/go/sql/parser.go
+++ b/go/sql/parser.go
@@ -18,19 +18,19 @@ var (
 	renameTableRegexp                    = regexp.MustCompile(`(?i)\brename\s+(to|as)\s+`)
 	alterTableExplicitSchemaTableRegexps = []*regexp.Regexp{
 		// ALTER TABLE `scm`.`tbl` something
-		regexp.MustCompile(`(?i)\balter\s+table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE `scm`.tbl something
-		regexp.MustCompile(`(?i)\balter\s+table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]([\S]+)\s+(.*$)`),
 		// ALTER TABLE scm.`tbl` something
-		regexp.MustCompile(`(?i)\balter\s+table\s+([\S]+)[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE scm.tbl something
-		regexp.MustCompile(`(?i)\balter\s+table\s+([\S]+)[.]([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)[.]([\S]+)\s+(.*$)`),
 	}
 	alterTableExplicitTableRegexps = []*regexp.Regexp{
 		// ALTER TABLE `tbl` something
-		regexp.MustCompile(`(?i)\balter\s+table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE tbl something
-		regexp.MustCompile(`(?i)\balter\s+table\s+([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)\s+(.*$)`),
 	}
 )
 
@@ -130,16 +130,16 @@ func (this *AlterTableParser) ParseAlterStatement(alterStatement string) (err er
 	this.alterStatementOptions = alterStatement
 	for _, alterTableRegexp := range alterTableExplicitSchemaTableRegexps {
 		if submatch := alterTableRegexp.FindStringSubmatch(this.alterStatementOptions); len(submatch) > 0 {
-			this.explicitSchema = submatch[1]
-			this.explicitTable = submatch[2]
-			this.alterStatementOptions = submatch[3]
+			this.explicitSchema = submatch[2]
+			this.explicitTable = submatch[3]
+			this.alterStatementOptions = submatch[4]
 			break
 		}
 	}
 	for _, alterTableRegexp := range alterTableExplicitTableRegexps {
 		if submatch := alterTableRegexp.FindStringSubmatch(this.alterStatementOptions); len(submatch) > 0 {
-			this.explicitTable = submatch[1]
-			this.alterStatementOptions = submatch[2]
+			this.explicitTable = submatch[2]
+			this.alterStatementOptions = submatch[3]
 			break
 		}
 	}

--- a/go/sql/parser.go
+++ b/go/sql/parser.go
@@ -18,19 +18,19 @@ var (
 	renameTableRegexp                    = regexp.MustCompile(`(?i)\brename\s+(to|as)\s+`)
 	alterTableExplicitSchemaTableRegexps = []*regexp.Regexp{
 		// ALTER TABLE `scm`.`tbl` something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE `scm`.tbl something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `[.]([\S]+)\s+(.*$)`),
 		// ALTER TABLE scm.`tbl` something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+([\S]+)[.]` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE scm.tbl something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)[.]([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+([\S]+)[.]([\S]+)\s+(.*$)`),
 	}
 	alterTableExplicitTableRegexps = []*regexp.Regexp{
 		// ALTER TABLE `tbl` something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+` + "`" + `([^` + "`" + `]+)` + "`" + `\s+(.*$)`),
 		// ALTER TABLE tbl something
-		regexp.MustCompile(`(?i)\balter\s+(online\s+|)table\s+([\S]+)\s+(.*$)`),
+		regexp.MustCompile(`(?i)\balter\s+(with_ghost\s+|)table\s+([\S]+)\s+(.*$)`),
 	}
 )
 

--- a/go/sql/parser_test.go
+++ b/go/sql/parser_test.go
@@ -297,4 +297,14 @@ func TestParseAlterStatementExplicitTable(t *testing.T) {
 		test.S(t).ExpectEquals(parser.alterStatementOptions, "drop column b, add index idx(i)")
 		test.S(t).ExpectTrue(reflect.DeepEqual(parser.alterTokens, []string{"drop column b", "add index idx(i)"}))
 	}
+	{
+		parser := NewAlterTableParser()
+		statement := "alter online table tbl drop column b"
+		err := parser.ParseAlterStatement(statement)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(parser.explicitSchema, "")
+		test.S(t).ExpectEquals(parser.explicitTable, "tbl")
+		test.S(t).ExpectEquals(parser.alterStatementOptions, "drop column b")
+		test.S(t).ExpectTrue(reflect.DeepEqual(parser.alterTokens, []string{"drop column b"}))
+	}
 }


### PR DESCRIPTION
This PR supports an experimental syntax: `ALTER ONLINE TABLE ...`, which has the same syntax as `ALTER TABLE` except for the addition of `ONLINE`.

This syntax isn't supported by MySQL: it is a Vitess experiment (PR link to follow) with special magic syntax. To that effect, `gh-ost` will silently accept `--alter="alter online table ..."` syntax as valid. It otherwise doesn't do anything special if the word `ONLINE` appears.