### PR TITLE
hooks: reporting GH_OST_ETA_SECONDS. ETA as part of migration context

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -483,6 +483,11 @@ func (this *MigrationContext) SetETADuration(etaDuration time.Duration) {
 	atomic.StoreInt64(&this.etaNanoseonds, etaDuration.Nanoseconds())
 }
 
+func (this *MigrationContext) GetETASeconds() int64 {
+	nano := atomic.LoadInt64(&this.etaNanoseonds)
+	return nano / int64(time.Second)
+}
+
 // math.Float64bits([f=0..100])
 
 // GetTotalRowsCopied returns the accurate number of rows being copied (affected)

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -182,6 +182,7 @@ type MigrationContext struct {
 	lastHeartbeatOnChangelogMutex          *sync.Mutex
 	CurrentLag                             int64
 	currentProgress                        uint64
+	etaNanoseonds                          int64
 	ThrottleHTTPStatusCode                 int64
 	controlReplicasLagResult               mysql.ReplicationLagResult
 	TotalRowsCopied                        int64
@@ -472,6 +473,14 @@ func (this *MigrationContext) GetProgressPct() float64 {
 
 func (this *MigrationContext) SetProgressPct(progressPct float64) {
 	atomic.StoreUint64(&this.currentProgress, math.Float64bits(progressPct))
+}
+
+func (this *MigrationContext) GetETADuration() time.Duration {
+	return time.Duration(atomic.LoadInt64(&this.etaNanoseonds))
+}
+
+func (this *MigrationContext) SetETADuration(etaDuration time.Duration) {
+	atomic.StoreInt64(&this.etaNanoseonds, etaDuration.Nanoseconds())
 }
 
 // math.Float64bits([f=0..100])

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -52,6 +52,7 @@ const (
 const (
 	HTTPStatusOK       = 200
 	MaxEventsBatchSize = 1000
+	ETAUnknown         = math.MinInt64
 )
 
 var (
@@ -268,6 +269,7 @@ func NewMigrationContext() *MigrationContext {
 		MaxLagMillisecondsThrottleThreshold: 1500,
 		CutOverLockTimeoutSeconds:           3,
 		DMLBatchSize:                        10,
+		etaNanoseonds:                       ETAUnknown,
 		maxLoad:                             NewLoadMap(),
 		criticalLoad:                        NewLoadMap(),
 		throttleMutex:                       &sync.Mutex{},
@@ -485,6 +487,9 @@ func (this *MigrationContext) SetETADuration(etaDuration time.Duration) {
 
 func (this *MigrationContext) GetETASeconds() int64 {
 	nano := atomic.LoadInt64(&this.etaNanoseonds)
+	if nano < 0 {
+		return ETAUnknown
+	}
 	return nano / int64(time.Second)
 }
 

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -66,6 +66,7 @@ func (this *HooksExecutor) applyEnvironmentVariables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_LAG=%f", this.migrationContext.GetCurrentLagDuration().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HEARTBEAT_LAG=%f", this.migrationContext.TimeSinceLastHeartbeatOnChangelog().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_PROGRESS=%f", this.migrationContext.GetProgressPct()))
+	env = append(env, fmt.Sprintf("GH_OST_ETA_SECONDS=%f", this.migrationContext.GetETADuration().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT=%s", this.migrationContext.HooksHintMessage))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_OWNER=%s", this.migrationContext.HooksHintOwner))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_TOKEN=%s", this.migrationContext.HooksHintToken))

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -66,7 +66,7 @@ func (this *HooksExecutor) applyEnvironmentVariables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_LAG=%f", this.migrationContext.GetCurrentLagDuration().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HEARTBEAT_LAG=%f", this.migrationContext.TimeSinceLastHeartbeatOnChangelog().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_PROGRESS=%f", this.migrationContext.GetProgressPct()))
-	env = append(env, fmt.Sprintf("GH_OST_ETA_SECONDS=%f", this.migrationContext.GetETADuration().Seconds()))
+	env = append(env, fmt.Sprintf("GH_OST_ETA_NANOSECONDS=%d", this.migrationContext.GetETADuration().Nanoseconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT=%s", this.migrationContext.HooksHintMessage))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_OWNER=%s", this.migrationContext.HooksHintOwner))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_TOKEN=%s", this.migrationContext.HooksHintToken))

--- a/go/logic/hooks.go
+++ b/go/logic/hooks.go
@@ -66,7 +66,7 @@ func (this *HooksExecutor) applyEnvironmentVariables(extraVariables ...string) [
 	env = append(env, fmt.Sprintf("GH_OST_INSPECTED_LAG=%f", this.migrationContext.GetCurrentLagDuration().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HEARTBEAT_LAG=%f", this.migrationContext.TimeSinceLastHeartbeatOnChangelog().Seconds()))
 	env = append(env, fmt.Sprintf("GH_OST_PROGRESS=%f", this.migrationContext.GetProgressPct()))
-	env = append(env, fmt.Sprintf("GH_OST_ETA_NANOSECONDS=%d", this.migrationContext.GetETADuration().Nanoseconds()))
+	env = append(env, fmt.Sprintf("GH_OST_ETA_SECONDS=%d", this.migrationContext.GetETASeconds()))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT=%s", this.migrationContext.HooksHintMessage))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_OWNER=%s", this.migrationContext.HooksHintOwner))
 	env = append(env, fmt.Sprintf("GH_OST_HOOKS_HINT_TOKEN=%s", this.migrationContext.HooksHintToken))

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -939,7 +939,7 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	}
 
 	var etaSeconds float64 = math.MaxFloat64
-	var etaDuration = time.Duration(math.MaxInt64)
+	var etaDuration = time.Duration(math.MinInt64)
 	if progressPct >= 100.0 {
 		etaDuration = 0
 	} else if progressPct >= 0.1 {
@@ -957,7 +957,7 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	switch etaDuration {
 	case 0:
 		eta = "due"
-	case time.Duration(math.MaxInt64):
+	case time.Duration(math.MinInt64):
 		eta = "N/A"
 	default:
 		eta = base.PrettifyDurationOutput(etaDuration)

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -939,7 +939,7 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	}
 
 	var etaSeconds float64 = math.MaxFloat64
-	var etaDuration = time.Duration(math.MinInt64)
+	var etaDuration = time.Duration(base.ETAUnknown)
 	if progressPct >= 100.0 {
 		etaDuration = 0
 	} else if progressPct >= 0.1 {
@@ -957,7 +957,7 @@ func (this *Migrator) printStatus(rule PrintStatusRule, writers ...io.Writer) {
 	switch etaDuration {
 	case 0:
 		eta = "due"
-	case time.Duration(math.MinInt64):
+	case time.Duration(base.ETAUnknown):
 		eta = "N/A"
 	default:
 		eta = base.PrettifyDurationOutput(etaDuration)


### PR DESCRIPTION
Hooks can now utilize `GH_OST_ETA_SECONDS` environment variable, populated with an integer value of ETA seconds.

A negative value stands for unknown ETA, as is the case at the very beginning of the migration.
The value is `0` when cut-over is imminent.