### PR TITLE
Support for triggers no rollback

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 	"github.com/openark/golib/log"
+	"github.com/openark/golib/sqlutils"
 
 	"github.com/go-ini/ini"
 )
@@ -153,9 +154,10 @@ type MigrationContext struct {
 	InitiallyDropOldTable        bool
 	InitiallyDropGhostTable      bool
 	TimestampOldTable            bool // Should old table name include a timestamp
+	IncludeTriggers              bool
 	CutOverType                  CutOver
 	ReplicaServerId              uint
-
+	
 	Hostname                               string
 	AssumeMasterHostname                   string
 	ApplierTimeZone                        string
@@ -219,6 +221,7 @@ type MigrationContext struct {
 	MappedSharedColumns              *sql.ColumnList
 	MigrationRangeMinValues          *sql.ColumnValues
 	MigrationRangeMaxValues          *sql.ColumnValues
+	Triggers                         []*sqlutils.RowMap
 	Iteration                        int64
 	MigrationIterationRangeMinValues *sql.ColumnValues
 	MigrationIterationRangeMaxValues *sql.ColumnValues

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -863,10 +863,10 @@ func (this *MigrationContext) ReadConfigFile() error {
 // getGhostTriggerName generates the name of a ghost trigger, based on original trigger name
 // or a given trigger name
 func (this *MigrationContext) GetGhostTriggerName(triggerName string) string {
-	if this.RemoveTriggerSuffix {
+	if this.RemoveTriggerSuffix && strings.HasSuffix(triggerName, this.TriggerSuffix){
 		return strings.TrimSuffix(triggerName, this.TriggerSuffix)
 	}
-
+	// else 
 	return triggerName + this.TriggerSuffix
 }
 

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -872,12 +872,7 @@ func (this *MigrationContext) GetGhostTriggerName(triggerName string) string {
 
 // validateGhostTriggerLength check if the ghost trigger name length is not more than 64 characters
 func (this *MigrationContext) ValidateGhostTriggerLengthBelowMaxLength(triggerName string) bool {
-	var ghostTriggerName string
-	if this.RemoveTriggerSuffix {
-		ghostTriggerName = strings.TrimSuffix(triggerName, this.TriggerSuffix)
-	} else {
-		ghostTriggerName = triggerName + this.TriggerSuffix
-	}
+	ghostTriggerName := this.GetGhostTriggerName(triggerName)
 
 	return utf8.RuneCountInString(ghostTriggerName) <= mysql.MaxTableNameLength
 }

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -863,10 +863,10 @@ func (this *MigrationContext) ReadConfigFile() error {
 // getGhostTriggerName generates the name of a ghost trigger, based on original trigger name
 // or a given trigger name
 func (this *MigrationContext) GetGhostTriggerName(triggerName string) string {
-	if this.RemoveTriggerSuffix && strings.HasSuffix(triggerName, this.TriggerSuffix){
+	if this.RemoveTriggerSuffix && strings.HasSuffix(triggerName, this.TriggerSuffix) {
 		return strings.TrimSuffix(triggerName, this.TriggerSuffix)
 	}
-	// else 
+	// else
 	return triggerName + this.TriggerSuffix
 }
 

--- a/go/base/context.go
+++ b/go/base/context.go
@@ -21,7 +21,6 @@ import (
 	"github.com/github/gh-ost/go/mysql"
 	"github.com/github/gh-ost/go/sql"
 	"github.com/openark/golib/log"
-	"github.com/openark/golib/sqlutils"
 
 	"github.com/go-ini/ini"
 )
@@ -229,7 +228,7 @@ type MigrationContext struct {
 	IncludeTriggers     bool
 	RemoveTriggerSuffix bool
 	TriggerSuffix       string
-	Triggers            []*sqlutils.RowMap
+	Triggers            []mysql.Trigger
 
 	recentBinlogCoordinates mysql.BinlogCoordinates
 
@@ -864,8 +863,7 @@ func (this *MigrationContext) ReadConfigFile() error {
 // getGhostTriggerName generates the name of a ghost trigger, based on original trigger name
 // or a given trigger name
 func (this *MigrationContext) GetGhostTriggerName(triggerName string) string {
-	// var triggerName string
-	if this.RemoveTriggerSuffix && strings.HasSuffix(triggerName, this.TriggerSuffix) {
+	if this.RemoveTriggerSuffix {
 		return strings.TrimSuffix(triggerName, this.TriggerSuffix)
 	}
 
@@ -873,13 +871,13 @@ func (this *MigrationContext) GetGhostTriggerName(triggerName string) string {
 }
 
 // validateGhostTriggerLength check if the ghost trigger name length is not more than 64 characters
-func (this *MigrationContext) ValidateGhostTriggerLengthBelow65chars(triggerName string) bool {
+func (this *MigrationContext) ValidateGhostTriggerLengthBelowMaxLength(triggerName string) bool {
 	var ghostTriggerName string
-	if this.RemoveTriggerSuffix && strings.HasSuffix(triggerName, this.TriggerSuffix) {
+	if this.RemoveTriggerSuffix {
 		ghostTriggerName = strings.TrimSuffix(triggerName, this.TriggerSuffix)
 	} else {
 		ghostTriggerName = triggerName + this.TriggerSuffix
 	}
 
-	return utf8.RuneCountInString(ghostTriggerName) < 65
+	return utf8.RuneCountInString(ghostTriggerName) <= mysql.MaxTableNameLength
 }

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +58,68 @@ func TestGetTableNames(t *testing.T) {
 		test.S(t).ExpectEquals(context.GetOldTableName(), "_tmp_del")
 		test.S(t).ExpectEquals(context.GetGhostTableName(), "_tmp_gho")
 		test.S(t).ExpectEquals(context.GetChangelogTableName(), "_tmp_ghc")
+	}
+}
+
+func TestGetTriggerNames(t *testing.T) {
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_gho"
+		test.S(t).ExpectEquals(context.GetGhostTriggerName("my_trigger"), "my_trigger"+context.TriggerSuffix)
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_gho"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.GetGhostTriggerName("my_trigger"), "my_trigger"+context.TriggerSuffix)
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_gho"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.GetGhostTriggerName("my_trigger_gho"), "my_trigger")
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_gho"
+		context.RemoveTriggerSuffix = false
+		test.S(t).ExpectEquals(context.GetGhostTriggerName("my_trigger_gho"), "my_trigger_gho_gho")
+	}
+
+}
+func TestValidateGhostTriggerLengthBelow65chars(t *testing.T) {
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_gho"
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars("my_trigger"), true)
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)), false) // 64 characters + "_ghost"
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 3)), true) // 48 characters + "_ghost"
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)), true) // 64 characters + "_ghost" removed
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)+"X"), false) // 65 characters + "_ghost" not removed
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)+"_ghost"), true) // 70 characters + last "_ghost"  removed
 	}
 }
 

--- a/go/base/context_test.go
+++ b/go/base/context_test.go
@@ -87,39 +87,39 @@ func TestGetTriggerNames(t *testing.T) {
 	}
 
 }
-func TestValidateGhostTriggerLengthBelow65chars(t *testing.T) {
+func TestValidateGhostTriggerLengthBelowMaxLength(t *testing.T) {
 	{
 		context := NewMigrationContext()
 		context.TriggerSuffix = "_gho"
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars("my_trigger"), true)
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength("my_trigger"), true)
 	}
 	{
 		context := NewMigrationContext()
 		context.TriggerSuffix = "_ghost"
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)), false) // 64 characters + "_ghost"
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength(strings.Repeat("my_trigger_ghost", 4)), false) // 64 characters + "_ghost"
 	}
 	{
 		context := NewMigrationContext()
 		context.TriggerSuffix = "_ghost"
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 3)), true) // 48 characters + "_ghost"
-	}
-	{
-		context := NewMigrationContext()
-		context.TriggerSuffix = "_ghost"
-		context.RemoveTriggerSuffix = true
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)), true) // 64 characters + "_ghost" removed
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength(strings.Repeat("my_trigger_ghost", 3)), true) // 48 characters + "_ghost"
 	}
 	{
 		context := NewMigrationContext()
 		context.TriggerSuffix = "_ghost"
 		context.RemoveTriggerSuffix = true
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)+"X"), false) // 65 characters + "_ghost" not removed
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength(strings.Repeat("my_trigger_ghost", 4)), true) // 64 characters + "_ghost" removed
 	}
 	{
 		context := NewMigrationContext()
 		context.TriggerSuffix = "_ghost"
 		context.RemoveTriggerSuffix = true
-		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelow65chars(strings.Repeat("my_trigger_ghost", 4)+"_ghost"), true) // 70 characters + last "_ghost"  removed
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength(strings.Repeat("my_trigger_ghost", 4)+"X"), false) // 65 characters + "_ghost" not removed
+	}
+	{
+		context := NewMigrationContext()
+		context.TriggerSuffix = "_ghost"
+		context.RemoveTriggerSuffix = true
+		test.S(t).ExpectEquals(context.ValidateGhostTriggerLengthBelowMaxLength(strings.Repeat("my_trigger_ghost", 4)+"_ghost"), true) // 70 characters + last "_ghost"  removed
 	}
 }
 

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -129,8 +129,8 @@ func main() {
 	flag.UintVar(&migrationContext.ReplicaServerId, "replica-server-id", 99999, "server id used by gh-ost process. Default: 99999")
 
 	flag.BoolVar(&migrationContext.IncludeTriggers, "include-triggers", false, "When true, the triggers (if exist) will be created on the new table")
-	flag.StringVar(&migrationContext.TriggerSuffix, "trigger-suffix", "", "have to be used with '--include-triggers'")
-	flag.BoolVar(&migrationContext.RemoveTriggerSuffix, "remove-trigger-suffix-if-exists", false, "Removal (instead of addition) of trigger suffix if it exists at the end of the original triger name. Have to be used with '--include-triggers' and '--TriggerSuffix'")
+	flag.StringVar(&migrationContext.TriggerSuffix, "trigger-suffix", "", "Add a suffix to the trigger name (i.e '_v2'). Requires '--include-triggers'")
+	flag.BoolVar(&migrationContext.RemoveTriggerSuffix, "remove-trigger-suffix-if-exists", false, "Remove given suffix from name of trigger. Requires '--include-triggers' and '--trigger-suffix'")
 
 	maxLoad := flag.String("max-load", "", "Comma delimited status-name=threshold. e.g: 'Threads_running=100,Threads_connected=500'. When status exceeds threshold, app throttles writes")
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
@@ -247,9 +247,9 @@ func main() {
 		migrationContext.Log.Fatalf("--trigger-suffix cannot be be used without --include-triggers")
 	}
 	if migrationContext.TriggerSuffix != "" {
-		regex, err := regexp.Compile(`^[\da-zA-Z_]+$`)
+		regex := regexp.MustCompile(`^[\da-zA-Z_]+$`)
 
-		if err != nil || !regex.Match([]byte(migrationContext.TriggerSuffix)) {
+		if !regex.Match([]byte(migrationContext.TriggerSuffix)) {
 			migrationContext.Log.Fatalf("--trigger-suffix must contain only alpha numeric characters and underscore (0-9,a-z,A-Z,_)")
 		}
 	}

--- a/go/cmd/gh-ost/main.go
+++ b/go/cmd/gh-ost/main.go
@@ -127,6 +127,8 @@ func main() {
 
 	flag.UintVar(&migrationContext.ReplicaServerId, "replica-server-id", 99999, "server id used by gh-ost process. Default: 99999")
 
+	flag.BoolVar(&migrationContext.IncludeTriggers, "include-triggers", false, "When true, the triggers (if exist) will be created on the new table")
+
 	maxLoad := flag.String("max-load", "", "Comma delimited status-name=threshold. e.g: 'Threads_running=100,Threads_connected=500'. When status exceeds threshold, app throttles writes")
 	criticalLoad := flag.String("critical-load", "", "Comma delimited status-name=threshold, same format as --max-load. When status exceeds threshold, app panics and quits")
 	flag.Int64Var(&migrationContext.CriticalLoadIntervalMilliseconds, "critical-load-interval-millis", 0, "When 0, migration immediately bails out upon meeting critical-load. When non-zero, a second check is done after given interval, and migration only bails out if 2nd check still meets critical load")

--- a/go/logic/applier.go
+++ b/go/logic/applier.go
@@ -273,27 +273,29 @@ func (this *Applier) dropTable(tableName string) error {
 }
 
 // dropTriggers drop the triggers on the applied host
-func (this *Applier) dropTriggers() error {
+func (this *Applier) DropTriggersFromGhost() error {
 	if len(this.migrationContext.Triggers) > 0 {
 		for _, trigger := range this.migrationContext.Triggers {
-			name := (*trigger).GetString("name")
-			query := fmt.Sprintf("drop trigger if exists %s", sql.EscapeName(name))
-			if _, err := sqlutils.ExecNoPrepare(this.db, query); err != nil {
+			triggerName := this.migrationContext.GetGhostTriggerName((*trigger).GetString("name"))
+			query := fmt.Sprintf("drop trigger if exists %s", sql.EscapeName(triggerName))
+			_, err := sqlutils.ExecNoPrepare(this.db, query)
+			if err != nil {
 				return err
 			}
-			this.migrationContext.Log.Infof("Trigger '%s' dropped", name)
+			this.migrationContext.Log.Infof("Trigger '%s' dropped", triggerName)
 		}
 	}
 	return nil
 }
 
 // createTriggers creates the triggers on the applied host
-func (this *Applier) createTriggers(tableName, suffix string) error {
+func (this *Applier) createTriggers(tableName string) error {
 	if len(this.migrationContext.Triggers) > 0 {
 		for _, trigger := range this.migrationContext.Triggers {
+			triggerName := this.migrationContext.GetGhostTriggerName((*trigger).GetString("name"))
 			query := fmt.Sprintf(`create /* gh-ost */ trigger %s %s %s on %s.%s for each row
 		%s`,
-				sql.EscapeName((*trigger).GetString("name")+suffix),
+				sql.EscapeName(triggerName),
 				(*trigger).GetString("timing"),
 				(*trigger).GetString("event"),
 				sql.EscapeName(this.migrationContext.DatabaseName),
@@ -301,93 +303,11 @@ func (this *Applier) createTriggers(tableName, suffix string) error {
 				(*trigger).GetString("statement"),
 			)
 			this.migrationContext.Log.Infof("Createing trigger %s on %s.%s",
-				sql.EscapeName((*trigger).GetString("name")+suffix),
+				sql.EscapeName(triggerName),
 				sql.EscapeName(this.migrationContext.DatabaseName),
 				sql.EscapeName(tableName),
 			)
 			if _, err := sqlutils.ExecNoPrepare(this.db, query); err != nil {
-				// tx.Rollback()
-				return err
-			}
-		}
-		this.migrationContext.Log.Infof("Triggers created on %s", tableName)
-	}
-	return nil
-}
-
-// createTriggersWithLock creates the triggers on the applied host while locking the table
-func (this *Applier) createTriggersWithLock(tableName string) error {
-	if len(this.migrationContext.Triggers) > 0 {
-		for _, trigger := range this.migrationContext.Triggers {
-			triggerName := (*trigger).GetString("name")
-			this.migrationContext.Log.Infof("Createing trigger %s on %s.%s",
-				sql.EscapeName(triggerName),
-				sql.EscapeName(this.migrationContext.DatabaseName),
-				sql.EscapeName(tableName),
-			)
-
-			// if err := this.LockOriginalTable(); err != nil {
-			// 	return err
-			// }
-
-			// tx, err := this.singletonDB.Begin()
-			tx, err := this.db.Begin()
-			if err != nil {
-				return err
-			}
-
-			// if _, err := tx.Exec("DELIMITER ;;"); err != nil {
-			// 	tx.Rollback()
-			// 	return err
-			// }
-			lockQuery := fmt.Sprintf(`lock /* gh-ost */ tables %s.%s write`,
-				sql.EscapeName(this.migrationContext.DatabaseName),
-				sql.EscapeName(this.migrationContext.OriginalTableName),
-			)
-			this.migrationContext.Log.Infof("Locking %s.%s",
-				sql.EscapeName(this.migrationContext.DatabaseName),
-				sql.EscapeName(this.migrationContext.OriginalTableName),
-			)
-			if _, err := tx.Exec(lockQuery); err != nil {
-				return err
-			}
-
-			if _, err := tx.Exec(fmt.Sprintf("drop trigger if exists %s", sql.EscapeName(triggerName+"_gho"))); err != nil {
-				return err
-			}
-
-			// if _, err := sqlutils.ExecNoPrepare(this.singletonDB, "DELIMITER ;;"); err != nil {
-			// 	return err
-			// }
-			// if _, err := sqlutils.ExecNoPrepare(this.singletonDB, fmt.Sprintf("drop trigger if exists %s", sql.EscapeName(triggerName+"_gho"))); err != nil {
-			// 	return err
-			// }
-
-			query := fmt.Sprintf(`create /* gh-ost */ trigger %s %s %s on %s for each row
-		%s`,
-				sql.EscapeName(triggerName),
-				(*trigger).GetString("timing"),
-				(*trigger).GetString("event"),
-				sql.EscapeName(tableName),
-				(*trigger).GetString("statement"),
-			)
-			// spew.Dump(query)
-			// if _, err := sqlutils.ExecNoPrepare(this.singletonDB, query); err != nil {
-			// 	return err
-			// }
-
-			if _, err := tx.Exec(query); err != nil {
-				tx.Rollback()
-				return err
-			}
-
-			// if _, err := tx.Exec("delimiter ;"); err != nil {
-			// 	tx.Rollback()
-			// 	return err
-			// }
-
-			if err := this.UnlockTables(); err != nil {
-				// tx.Rollback()
 				return err
 			}
 		}
@@ -397,20 +317,15 @@ func (this *Applier) createTriggersWithLock(tableName string) error {
 }
 
 // ReCreateTriggers creates the original triggers on applier host
-func (this *Applier) CreateTriggersOnGhost(tableLocked chan<- error) error {
-	err := this.createTriggers(this.migrationContext.GetGhostTableName(), "_gho")
+func (this *Applier) CreateTriggersOnGhostAtomic(tableLocked chan<- error) error {
+	err := this.createTriggers(this.migrationContext.GetGhostTableName())
 	tableLocked <- err
 	return err
 }
 
 // ReCreateTriggers creates the original triggers on applier host
-func (this *Applier) CreateTriggersOnSource(triggersMigrated chan<- error) error {
-	if err := this.dropTriggers(); err != nil { // first lets drop original triggers
-		triggersMigrated <- err
-		return err
-	}
-	err := this.createTriggersWithLock(this.migrationContext.DatabaseName + "." + this.migrationContext.OriginalTableName)
-	triggersMigrated <- err
+func (this *Applier) CreateTriggersOnGhost() error {
+	err := this.createTriggers(this.migrationContext.GetGhostTableName())
 	return err
 }
 

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -531,7 +531,7 @@ func (this *Inspector) validateGhostTriggersDontExist() error {
 	if len(this.migrationContext.Triggers) > 0 {
 		var foundTriggers []string
 		for _, trigger := range this.migrationContext.Triggers {
-			triggerName := this.migrationContext.GetGhostTriggerName((*trigger).GetString("name"))
+			triggerName := this.migrationContext.GetGhostTriggerName(trigger.Name)
 			query := "select 1 from information_schema.triggers where trigger_name = ? and trigger_schema = ?"
 			err := sqlutils.QueryRowsMap(this.db, query, func(rowMap sqlutils.RowMap) error {
 				triggerExists := rowMap.GetInt("1")
@@ -559,8 +559,8 @@ func (this *Inspector) validateGhostTriggersLength() error {
 	if len(this.migrationContext.Triggers) > 0 {
 		var foundTriggers []string
 		for _, trigger := range this.migrationContext.Triggers {
-			triggerName := this.migrationContext.GetGhostTriggerName((*trigger).GetString("name"))
-			if ok := this.migrationContext.ValidateGhostTriggerLengthBelow65chars(triggerName); !ok {
+			triggerName := this.migrationContext.GetGhostTriggerName(trigger.Name)
+			if ok := this.migrationContext.ValidateGhostTriggerLengthBelowMaxLength(triggerName); !ok {
 				foundTriggers = append(foundTriggers, triggerName)
 			}
 

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -505,7 +505,16 @@ func (this *Inspector) validateTableTriggers() error {
 		return err
 	}
 	if numTriggers > 0 {
-		return this.migrationContext.Log.Errorf("Found triggers on %s.%s. Triggers are not supported at this time. Bailing out", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+		if this.migrationContext.IncludeTriggers {
+			this.migrationContext.Log.Infof("Found %d triggers on %s.%s.", numTriggers, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+			this.migrationContext.Triggers, err = mysql.GetTriggers(this.db, this.migrationContext.DatabaseName, this.migrationContext.OriginalTableName)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		return this.migrationContext.Log.Errorf("Found triggers on %s.%s. Tables with triggers are supported only when using \"include-triggers\" flag. Bailing out", sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+
 	}
 	this.migrationContext.Log.Debugf("Validated no triggers exist on table")
 	return nil

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -566,7 +566,7 @@ func (this *Inspector) validateGhostTriggersLength() error {
 
 		}
 		if len(foundTriggers) > 0 {
-			return this.migrationContext.Log.Errorf("Gh-ost triggers (%s) length > %d characters. Bailing out", strings.Join(foundTriggers, ","),mysql.MaxTableNameLength)
+			return this.migrationContext.Log.Errorf("Gh-ost triggers (%s) length > %d characters. Bailing out", strings.Join(foundTriggers, ","), mysql.MaxTableNameLength)
 		}
 	}
 

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -566,7 +566,7 @@ func (this *Inspector) validateGhostTriggersLength() error {
 
 		}
 		if len(foundTriggers) > 0 {
-			return this.migrationContext.Log.Errorf("Gh-ost triggers (%s) length > 64 characters. Bailing out", strings.Join(foundTriggers, ","))
+			return this.migrationContext.Log.Errorf("Gh-ost triggers (%s) length > %d characters. Bailing out", strings.Join(foundTriggers, ","),mysql.MaxTableNameLength)
 		}
 	}
 

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -671,14 +671,8 @@ func (this *Migrator) atomicCutOver() (err error) {
 
 	// If we need to create triggers we need to do it here (only create part)
 	if this.migrationContext.IncludeTriggers && len(this.migrationContext.Triggers) > 0 {
-		triggersCreated := make(chan error, 2)
-		go func() {
-			if err := this.applier.CreateTriggersOnGhostAtomic(triggersCreated); err != nil {
-				this.migrationContext.Log.Errore(err)
-			}
-		}()
-		if err := <-triggersCreated; err != nil {
-			return this.migrationContext.Log.Errore(err)
+		if err := this.applier.CreateTriggersOnGhost(); err != nil {
+			this.migrationContext.Log.Errore(err)
 		}
 	}
 

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -31,10 +31,10 @@ type ReplicationLagResult struct {
 }
 
 type Trigger struct {
-	Name string
-	Event string
+	Name      string
+	Event     string
 	Statement string
-	Timing string
+	Timing    string
 }
 
 func NewNoReplicationLagResult() *ReplicationLagResult {
@@ -221,10 +221,10 @@ func GetTriggers(db *gosql.DB, databaseName, tableName string) (triggers []Trigg
 
 	err = sqlutils.QueryRowsMap(db, query, func(rowMap sqlutils.RowMap) error {
 		triggers = append(triggers, Trigger{
-			Name: rowMap.GetString("name"),
-			Event: rowMap.GetString("event"),
+			Name:      rowMap.GetString("name"),
+			Event:     rowMap.GetString("event"),
 			Statement: rowMap.GetString("statement"),
-			Timing: rowMap.GetString("timing"),
+			Timing:    rowMap.GetString("timing"),
 		})
 		return nil
 	})

--- a/go/mysql/utils.go
+++ b/go/mysql/utils.go
@@ -205,3 +205,19 @@ func GetTableColumns(db *gosql.DB, databaseName, tableName string) (*sql.ColumnL
 	}
 	return sql.NewColumnList(columnNames), sql.NewColumnList(virtualColumnNames), nil
 }
+
+// GetTriggers reads trigger list from given table
+func GetTriggers(db *gosql.DB, databaseName, tableName string) (triggers []*sqlutils.RowMap, err error) {
+	query := fmt.Sprintf(`select trigger_name as name, event_manipulation as event, action_statement as statement, action_timing as timing
+	from information_schema.triggers 
+	where trigger_schema = '%s' and event_object_table = '%s'`, databaseName, tableName)
+	
+	err = sqlutils.QueryRowsMap(db, query, func(rowMap sqlutils.RowMap) error {
+		triggers = append(triggers, &rowMap)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return triggers, nil
+}


### PR DESCRIPTION
Hi @shlomi-noach ,

Here is a working version of trigger support.
3 new flag added:
  1. _include-triggers_ - When true, the triggers (if exist) will be created on the new table
  2. _trigger-suffix_
  3. _remove-trigger-suffix-if-exists_ - Removal (instead of addition) of trigger suffix if it exists at the end of the original trigger name. 

As agreed, we create a ghost trigger instead of a complete trigger migration.

One thing I'm confuse about is the rollback: Incase there is a rollback and the ghost table is either not in use or dropped, then why do we need to do any rollback on the ghost triggers?